### PR TITLE
Add support for Events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -217,7 +217,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -421,7 +421,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.5"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
+checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
 dependencies = [
  "jobserver",
  "libc",
@@ -759,7 +759,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -770,7 +770,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -831,7 +831,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -841,7 +841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -890,7 +890,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -1131,7 +1131,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -1270,9 +1270,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "half"
@@ -1369,7 +1369,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -1612,7 +1612,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "imbl-sized-chunks"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144006fb58ed787dcae3f54575ff4349755b00ccc99f4b4873860b654be1ed63"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
 dependencies = [
  "bitmaps",
 ]
@@ -2036,7 +2036,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -2255,7 +2255,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "onpurpose"
-version = "0.1.114"
+version = "0.1.115"
 dependencies = [
  "ahash 0.8.11",
  "better_term",
@@ -2298,7 +2298,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -2468,7 +2468,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "unicase",
 ]
 
@@ -2543,7 +2543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -2596,7 +2596,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "version_check",
  "yansi",
 ]
@@ -2702,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2834,7 +2834,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -2877,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2910,6 +2910,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2948,7 +2949,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -3186,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -3255,9 +3256,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -3273,13 +3274,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -3309,9 +3310,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3327,14 +3328,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -3727,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3753,7 +3754,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -3823,7 +3824,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -3834,7 +3835,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -3938,7 +3939,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -3998,6 +3999,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4022,7 +4044,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -4092,9 +4114,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -4255,7 +4277,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "wasm-bindgen-shared",
 ]
 
@@ -4290,7 +4312,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4510,9 +4532,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
 dependencies = [
  "memchr",
 ]
@@ -4583,7 +4605,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "synstructure",
 ]
 
@@ -4605,7 +4627,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -4625,7 +4647,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "synstructure",
 ]
 
@@ -4654,7 +4676,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onpurpose"
-version = "0.1.114"
+version = "0.1.115"
 edition = "2021"
 
 [dependencies]

--- a/console/src/base_data/event.rs
+++ b/console/src/base_data/event.rs
@@ -1,0 +1,45 @@
+use chrono::{DateTime, Utc};
+use surrealdb::opt::RecordId;
+
+use crate::data_storage::surrealdb_layer::surreal_event::SurrealEvent;
+
+#[derive(Debug, Eq)]
+pub(crate) struct Event<'s> {
+    id: &'s RecordId,
+    last_updated: DateTime<Utc>,
+    surreal_event: &'s SurrealEvent,
+}
+
+impl PartialEq for Event<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl<'s> Event<'s> {
+    pub(crate) fn new(surreal_event: &'s SurrealEvent) -> Self {
+        let id = surreal_event.id.as_ref().expect("In DB");
+        let last_updated = surreal_event.last_updated.clone().into();
+        Event {
+            id,
+            surreal_event,
+            last_updated,
+        }
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        !self.surreal_event.triggered
+    }
+
+    pub(crate) fn get_surreal_record_id(&self) -> &RecordId {
+        self.id
+    }
+
+    pub(crate) fn get_summary(&self) -> &str {
+        &self.surreal_event.summary
+    }
+
+    pub(crate) fn get_last_updated(&self) -> &DateTime<Utc> {
+        &self.last_updated
+    }
+}

--- a/console/src/calculated_data.rs
+++ b/console/src/calculated_data.rs
@@ -1,6 +1,7 @@
 use crate::{
     base_data::{
-        in_the_moment_priority::InTheMomentPriorityWithItemAction, time_spent::TimeSpent, BaseData,
+        event::Event, in_the_moment_priority::InTheMomentPriorityWithItemAction,
+        time_spent::TimeSpent, BaseData,
     },
     node::{item_node::ItemNode, item_status::ItemStatus, mode_node::ModeNode},
     systems::do_now_list::current_mode::CurrentMode,
@@ -45,7 +46,7 @@ impl CalculatedData {
                     .map(|(k, x)| {
                         (
                             *k,
-                            ItemNode::new(x, base_data.get_items(), base_data.get_time_spent_log()),
+                            ItemNode::new(x, base_data.get_items(), base_data.get_events(), base_data.get_time_spent_log()),
                         )
                     })
                     .collect::<HashMap<_, _>>()
@@ -115,5 +116,13 @@ impl CalculatedData {
 
     pub(crate) fn get_mode_nodes(&self) -> &[ModeNode] {
         self.borrow_mode_nodes()
+    }
+
+    pub(crate) fn get_events(&self) -> &HashMap<&RecordId, Event> {
+        self.borrow_base_data().get_events()
+    }
+
+    pub(crate) fn get_base_data(&self) -> &BaseData {
+        self.borrow_base_data()
     }
 }

--- a/console/src/data_storage/surrealdb_layer.rs
+++ b/console/src/data_storage/surrealdb_layer.rs
@@ -6,6 +6,7 @@ use surrealdb::{
 
 pub(crate) mod data_layer_commands;
 pub(crate) mod surreal_current_mode;
+pub(crate) mod surreal_event;
 pub(crate) mod surreal_in_the_moment_priority;
 pub(crate) mod surreal_item;
 pub(crate) mod surreal_mode;

--- a/console/src/data_storage/surrealdb_layer/surreal_event.rs
+++ b/console/src/data_storage/surrealdb_layer/surreal_event.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+use surrealdb::sql::{Datetime, Thing};
+
+use crate::new_event::NewEvent;
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, Clone, Debug)]
+pub(crate) struct SurrealEvent {
+    pub(crate) id: Option<Thing>,
+    pub(crate) version: u32,
+    pub(crate) last_updated: Datetime,
+    pub(crate) triggered: bool,
+    pub(crate) summary: String,
+}
+
+impl From<NewEvent> for SurrealEvent {
+    fn from(new_event: NewEvent) -> Self {
+        SurrealEvent {
+            id: None,
+            version: 0,
+            last_updated: new_event.last_updated.into(),
+            triggered: new_event.triggered,
+            summary: new_event.summary,
+        }
+    }
+}
+
+impl SurrealEvent {
+    pub(crate) const TABLE_NAME: &'static str = "events";
+}

--- a/console/src/data_storage/surrealdb_layer/surreal_tables.rs
+++ b/console/src/data_storage/surrealdb_layer/surreal_tables.rs
@@ -6,12 +6,12 @@ use tokio::sync::mpsc::Sender;
 #[cfg(test)]
 use derive_builder::Builder;
 
-use crate::base_data::{item::Item, mode::Mode, time_spent::TimeSpent};
+use crate::base_data::{event::Event, item::Item, mode::Mode, time_spent::TimeSpent};
 
 use super::{
     data_layer_commands::DataLayerCommands, surreal_current_mode::SurrealCurrentMode,
-    surreal_in_the_moment_priority::SurrealInTheMomentPriority, surreal_item::SurrealItem,
-    surreal_mode::SurrealMode, surreal_time_spent::SurrealTimeSpent,
+    surreal_event::SurrealEvent, surreal_in_the_moment_priority::SurrealInTheMomentPriority,
+    surreal_item::SurrealItem, surreal_mode::SurrealMode, surreal_time_spent::SurrealTimeSpent,
 };
 
 #[derive(Clone, Debug)]
@@ -31,6 +31,9 @@ pub(crate) struct SurrealTables {
 
     #[cfg_attr(test, builder(default))]
     pub(crate) surreal_modes: Vec<SurrealMode>,
+
+    #[cfg_attr(test, builder(default))]
+    pub(crate) surreal_events: Vec<SurrealEvent>,
 }
 
 impl SurrealTables {
@@ -47,6 +50,13 @@ impl SurrealTables {
         self.surreal_items
             .iter()
             .map(|x| (x.id.as_ref().expect("In DB"), x.make_item(now)))
+            .collect()
+    }
+
+    pub(crate) fn make_events(&self) -> HashMap<&RecordId, Event<'_>> {
+        self.surreal_events
+            .iter()
+            .map(|x| (x.id.as_ref().expect("In DB"), Event::new(x)))
             .collect()
     }
 

--- a/console/src/display/display_dependencies_with_item_node.rs
+++ b/console/src/display/display_dependencies_with_item_node.rs
@@ -55,6 +55,9 @@ impl Display for DisplayDependenciesWithItemNode<'_> {
                     DependencyWithItemNode::WaitingToBeInterrupted => {
                         write!(f, "Waiting to be interrupted")?
                     }
+                    DependencyWithItemNode::AfterEvent(event) => {
+                        write!(f, "After event {}", event.get_summary())?
+                    }
                 }
             }
             Ok(())

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -3,6 +3,7 @@ pub(crate) mod calculated_data;
 pub(crate) mod data_storage;
 pub(crate) mod display;
 pub(crate) mod menu;
+pub(crate) mod new_event;
 pub(crate) mod new_item;
 pub(crate) mod new_mode;
 pub(crate) mod new_time_spent;

--- a/console/src/menu/inquire/back_menu.rs
+++ b/console/src/menu/inquire/back_menu.rs
@@ -821,11 +821,12 @@ async fn debug_view_all_items(
     let base_data = BaseData::new_from_surreal_tables(surreal_tables, now);
     let all_items = base_data.get_items();
     let active_items = base_data.get_active_items();
+    let all_events = base_data.get_events();
     let time_spent_log = base_data.get_time_spent_log();
 
     let item_nodes = active_items
         .iter()
-        .map(|x| ItemNode::new(x, all_items, time_spent_log))
+        .map(|x| ItemNode::new(x, all_items, all_events, time_spent_log))
         .collect::<Vec<_>>();
 
     let item_nodes = item_nodes.iter().collect::<Vec<_>>();

--- a/console/src/menu/inquire/do_now_list_menu/do_now_list_single_item.rs
+++ b/console/src/menu/inquire/do_now_list_menu/do_now_list_single_item.rs
@@ -293,11 +293,13 @@ pub(crate) async fn present_do_now_list_item_selected(
             Ok(())
         }
         Ok(DoNowListSingleItemSelection::UnableToDoThisRightNow) => {
+            let base_data = do_now_list.get_base_data();
             present_set_ready_and_urgency_plan_menu(
                 menu_for,
                 why_in_scope,
                 menu_for.get_urgency_now().cloned(),
                 LogTime::PartOfAnotherTaskDoNotLogTheTime,
+                base_data,
                 send_to_data_storage_layer,
             )
             .await
@@ -307,6 +309,7 @@ pub(crate) async fn present_do_now_list_item_selected(
                 .await
         }
         Ok(DoNowListSingleItemSelection::ReviewItem) => {
+            let base_data = do_now_list.get_base_data();
             review_item::present_review_item_menu(
                 menu_for,
                 menu_for
@@ -316,16 +319,19 @@ pub(crate) async fn present_do_now_list_item_selected(
                 why_in_scope,
                 do_now_list.get_all_items_status(),
                 LogTime::PartOfAnotherTaskDoNotLogTheTime,
+                base_data,
                 send_to_data_storage_layer,
             )
             .await
         }
         Ok(DoNowListSingleItemSelection::WorkedOnThis) => {
+            let base_data = do_now_list.get_base_data();
             present_set_ready_and_urgency_plan_menu(
                 menu_for,
                 why_in_scope,
                 menu_for.get_urgency_now().cloned(),
                 LogTime::PartOfAnotherTaskDoNotLogTheTime,
+                base_data,
                 send_to_data_storage_layer,
             )
             .await?;
@@ -355,11 +361,13 @@ pub(crate) async fn present_do_now_list_item_selected(
             .await
         }
         Ok(DoNowListSingleItemSelection::ChangeReadyAndUrgencyPlan) => {
+            let base_data = do_now_list.get_base_data();
             present_set_ready_and_urgency_plan_menu(
                 menu_for,
                 why_in_scope,
                 menu_for.get_urgency_now().cloned(),
                 LogTime::PartOfAnotherTaskDoNotLogTheTime,
+                base_data,
                 send_to_data_storage_layer,
             )
             .await
@@ -616,6 +624,7 @@ async fn finish_do_now_item(
             let now = Utc::now();
             let base_data = BaseData::new_from_surreal_tables(surreal_tables, now);
             let items = base_data.get_items();
+            let events = base_data.get_events();
             let parent_surreal_record_id = parent.get_surreal_record_id();
             let time_spent_log = base_data.get_time_spent_log();
             let updated_parent = ItemNode::new(
@@ -623,6 +632,7 @@ async fn finish_do_now_item(
                     .get(parent_surreal_record_id)
                     .expect("Should be there"),
                 items,
+                events,
                 time_spent_log,
             );
 
@@ -680,10 +690,11 @@ async fn parent_to_item(
     let base_data = BaseData::new_from_surreal_tables(raw_data, now);
     let items = base_data.get_items();
     let active_items = base_data.get_active_items();
+    let events = base_data.get_events();
     let time_spent_log = base_data.get_time_spent_log();
     let item_nodes = active_items
         .iter()
-        .map(|x| ItemNode::new(x, items, time_spent_log))
+        .map(|x| ItemNode::new(x, items, events, time_spent_log))
         .collect::<Vec<_>>();
     let list = DisplayItemNode::make_list(&item_nodes, Filter::Active, DisplayFormat::SingleLine);
 

--- a/console/src/menu/inquire/do_now_list_menu/do_now_list_single_item/give_this_item_a_parent.rs
+++ b/console/src/menu/inquire/do_now_list_menu/do_now_list_single_item/give_this_item_a_parent.rs
@@ -47,11 +47,12 @@ pub(crate) async fn give_this_item_a_parent(
     let base_data = BaseData::new_from_surreal_tables(surreal_tables, now);
     let all_items = base_data.get_items();
     let active_items = base_data.get_active_items();
+    let all_events = base_data.get_events();
     let time_spent_log = base_data.get_time_spent_log();
     let mut nodes = active_items
         .iter()
         .filter(|x| x.get_surreal_record_id() != parent_this.get_surreal_record_id())
-        .map(|item| ItemNode::new(item, all_items, time_spent_log))
+        .map(|item| ItemNode::new(item, all_items, all_events, time_spent_log))
         //Collect the ItemNodes because they need a place to be so they don't go out of scope as DisplayItemNode
         //only takes a reference.
         .collect::<Vec<_>>();

--- a/console/src/menu/inquire/do_now_list_menu/pick_what_should_be_done_first.rs
+++ b/console/src/menu/inquire/do_now_list_menu/pick_what_should_be_done_first.rs
@@ -143,12 +143,14 @@ pub(crate) async fn present_pick_what_should_be_done_first_menu<'a>(
                     .await;
                 }
                 ActionWithItemStatus::ReviewItem(item_status) => {
+                    let base_data = do_now_list.get_base_data();
                     return present_review_item_menu(
                         item_status,
                         item_action.get_urgency_now(),
                         why_in_scope,
                         do_now_list.get_all_items_status(),
                         LogTime::SeparateTaskLogTheTime,
+                        base_data,
                         send_to_data_storage_layer,
                     )
                     .await;
@@ -181,11 +183,13 @@ pub(crate) async fn present_pick_what_should_be_done_first_menu<'a>(
                     .await;
                 }
                 ActionWithItemStatus::SetReadyAndUrgency(item_status) => {
+                    let base_data = do_now_list.get_base_data();
                     return present_set_ready_and_urgency_plan_menu(
                         item_status,
                         why_in_scope,
                         Some(item_action.get_urgency_now()),
                         LogTime::SeparateTaskLogTheTime,
+                        base_data,
                         send_to_data_storage_layer,
                     )
                     .await;

--- a/console/src/new_event.rs
+++ b/console/src/new_event.rs
@@ -1,0 +1,14 @@
+use chrono::{DateTime, Utc};
+use derive_builder::Builder;
+
+#[derive(Builder, Clone, Debug)]
+#[builder(setter(into))]
+pub(crate) struct NewEvent {
+    pub(crate) summary: String,
+
+    #[builder(default = "false")]
+    pub(crate) triggered: bool,
+
+    #[builder(default = "Utc::now()")]
+    pub(crate) last_updated: DateTime<Utc>,
+}

--- a/console/src/new_item.rs
+++ b/console/src/new_item.rs
@@ -2,12 +2,15 @@ use chrono::{DateTime, Utc};
 use derive_builder::Builder;
 use surrealdb::sql::Datetime;
 
-use crate::data_storage::surrealdb_layer::surreal_item::{
-    Responsibility, SurrealDependency, SurrealFrequency, SurrealItemType, SurrealLap,
-    SurrealReviewGuidance, SurrealUrgencyPlan,
+use crate::{
+    data_storage::surrealdb_layer::surreal_item::{
+        Responsibility, SurrealDependency, SurrealFrequency, SurrealItemType, SurrealLap,
+        SurrealReviewGuidance, SurrealUrgencyPlan,
+    },
+    new_event::NewEvent,
 };
 
-#[derive(Builder)]
+#[derive(Builder, Clone, Debug)]
 #[builder(setter(into))]
 pub(crate) struct NewItem {
     pub(crate) summary: String,
@@ -31,7 +34,7 @@ pub(crate) struct NewItem {
     pub(crate) lap: Option<SurrealLap>,
 
     #[builder(default)]
-    pub(crate) dependencies: Vec<SurrealDependency>,
+    pub(crate) dependencies: Vec<NewDependency>,
 
     #[builder(default)]
     pub(crate) last_reviewed: Option<DateTime<Utc>>,
@@ -41,6 +44,15 @@ pub(crate) struct NewItem {
 
     #[builder(default)]
     pub(crate) review_guidance: Option<SurrealReviewGuidance>,
+}
+
+/// This type exists because it is possible to add a new event to a new item meaning that both need to be created at the same time.
+#[derive(Clone, Debug)]
+pub(crate) enum NewDependency {
+    /// Dependency already exists in the database.
+    Existing(SurrealDependency),
+    /// Dependency is a new event that needs to be created.
+    NewEvent(NewEvent),
 }
 
 impl NewItem {

--- a/console/src/systems/do_now_list.rs
+++ b/console/src/systems/do_now_list.rs
@@ -7,7 +7,7 @@ use surrealdb::opt::RecordId;
 pub(crate) mod current_mode;
 
 use crate::{
-    base_data::time_spent::TimeSpent,
+    base_data::{event::Event, time_spent::TimeSpent, BaseData},
     calculated_data::CalculatedData,
     data_storage::surrealdb_layer::surreal_item::SurrealUrgency,
     node::{
@@ -173,6 +173,14 @@ impl DoNowList {
 
     pub(crate) fn get_current_mode(&self) -> &CurrentMode {
         self.borrow_calculated_data().get_current_mode()
+    }
+
+    pub(crate) fn get_events(&self) -> &HashMap<&RecordId, Event> {
+        self.borrow_calculated_data().get_events()
+    }
+
+    pub(crate) fn get_base_data(&self) -> &BaseData {
+        self.borrow_calculated_data().get_base_data()
     }
 }
 


### PR DESCRIPTION
An event is something that can happen to uncover additional items that can now be done. For example you can say that I need to wait until I get home before I can do this item and then
a wait until you are home event needs to be triggered. This shows up in the menu and you can trigger the event or see all of the items waiting on this event.